### PR TITLE
DKG specification updates related to disqualification

### DIFF
--- a/dkg/dkg.py
+++ b/dkg/dkg.py
@@ -64,7 +64,7 @@ for j in goodParticipants[2], j != i:
 # tag::phase-3[]
 # GJKR 1.(a):
 #  f_i(z) = a_i0 + a_i1 * z + ... + a_it * z^t
-#  f'_i(z) = b_i0 + b_i1 * z + ... + b_it * z^t
+#  g_i(z) = b_i0 + b_i1 * z + ... + b_it * z^t
 #
 # a_ij = sharePolyCoeffs[j]
 # b_ij = blindingFactors[j]

--- a/dkg/dkg.py
+++ b/dkg/dkg.py
@@ -122,6 +122,8 @@ broadcast(messagePhase3(encryptedShares, self.commitments))
 #     DQ if payload absent
 # - the length of each payload must be: 2 * G1_SCALAR_LENGTH + MAC_LENGTH
 #     DQ if a payload has incorrect length
+# - P_i must be able to decrypt the payload received from P_j
+#     DQ if payload cannot be decrypted
 #
 messages.receive(3)
 
@@ -130,11 +132,18 @@ shareComplaints = []
 for j in goodParticipants[4], j != i:
     k_ij = self.symkey[j]
 
+    if not validPayload(
+        senderIndex = j,
+        recipientIndex = i,
+    ):
+        X_ij = self.ephemeralKey[j]
+        shareComplaints.append(shareComplaint(j, X_ij))
+
     validShares = decryptAndValidateShares(
         senderIndex = j,
         recipientIndex = i,
         symkey = k_ij
-     )
+    )
 
     if not validShares:
         X_ij = self.ephemeralKey[j]

--- a/dkg/dkg_util.py
+++ b/dkg/dkg_util.py
@@ -119,7 +119,7 @@ def checkShareConsistency(
     C_i = commitments(i)
 
     C_ecSum = ecSum(
-        [ C_i[k].scalarMult(j^k) for k in [0..M] ]
+        [ C_i[k].scalarMult(j^k) for k in [0..T] ]
     )
 
     sharesValid = ecCommit(share_S, share_T) == C_ecSum


### PR DESCRIPTION
PR related to @pdyraga [comment](https://github.com/keep-network/keep-core/pull/999#discussion_r318441106). A specification update is needed because of the new disqualification case in phase 4 introduced by [DKG DQ Handling - Phase 5 - part 3](https://github.com/keep-network/keep-core/pull/999).

Apart from that, this PR introduces fixes of little spec inconsistencies detected during DQ implementation.